### PR TITLE
Verifica conexão com a rede

### DIFF
--- a/bingwallpapers.sh
+++ b/bingwallpapers.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Verifica a conexão com a internet
+ping www.google.com -c 1 >/dev/null;
+if [ "$?" != "0" ] ;
+then
+   exit
+fi
+
 bing="www.bing.com"
 
 # Parametros válidos: pt-BR, en-US, zh-CN, ja-JP, en-AU, en-UK, de-DE, en-NZ, en-CA.


### PR DESCRIPTION
Atualmente o script não verificava a conexão com a rede antes de buscar um novo wallpaper, com isso caso não houvesse conexão ele setava uma imagem vazia. A partir dessa modificação é feito um teste de rede antes de executar o script.
